### PR TITLE
refactor sort

### DIFF
--- a/src/app/table/table.component.html
+++ b/src/app/table/table.component.html
@@ -1,18 +1,10 @@
-<!--
-    TODO:
-    on click of button.th-sortable
-    1. add aria-sort with appropriate value to sorted th https://www.w3.org/WAI/PF/aria/states_and_properties#aria-sort
-    2. toggle icon (icon-caret-down, icon-caret-up)
-    3. toggle opacity (.5 for inactive, 1 for active)
-    4. only apply 1-3 to ONE th at a time
--->
 <table class="table">
     <thead>
         <tr>
             <ng-container *ngIf="columnValue">
                 <th scope="col" [attr.aria-sort]="isSortActive ? getAriaSortOrder(i) : null"
                     *ngFor="let column of columnValue; let i = index;">
-                    <button (click)="applySort(column.key, i)" class="th-sortable" [ngClass]="getSortClasses(i, 'class')">
+                    <button class="th-sortable" (click)="applySort(column.key, i)">
                         {{column.value}}
                     </button>
                 </th>

--- a/src/app/table/table.component.scss
+++ b/src/app/table/table.component.scss
@@ -23,6 +23,8 @@
             .th-sortable
             {
                 position: relative;
+                display: flex;
+                justify-content: space-between;
                 width: 100%;
                 height: 100%;
                 border: 0;
@@ -36,35 +38,35 @@
 
                 &::after
                 {
-                    position: absolute;
-                    right: 15px;
+                    content: $icon-caret-down;
+                    margin-left: 10px;
                     font-family: $font-family-icon;
                     transform: translateY(2px);
                     opacity: .5;
                 }
+            }
 
-                &.active
+            &[aria-sort]
+            {
+                .th-sortable::after
                 {
-                    &::after
-                    {
-                        opacity: 1;
-                    }
+                    opacity: 1;
                 }
+            }
 
-                &.ascending
+            &[aria-sort="ascending"]
+            {
+                .th-sortable::after
                 {
-                    &::after
-                    {
-                        content: $icon-caret-up;
-                    }
+                    content: $icon-caret-up;
                 }
+            }
 
-                &.descending
+            &[aria-sort="descending"]
+            {
+                .th-sortable::after
                 {
-                    &::after
-                    {
-                        content: $icon-caret-down;
-                    }
+                    content: $icon-caret-down;
                 }
             }
         }

--- a/src/app/table/table.component.ts
+++ b/src/app/table/table.component.ts
@@ -6,16 +6,16 @@ import { TabledataService } from '../service/tabledata.service';
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.scss']
 })
+
 export class TableComponent implements OnInit, OnDestroy {
   allData: [] = [];
   columnValue: any;
   loadService: any;
+  defaultSortColName  = 'amount';
+  colIndex: number;
   sortOrder: string;
-  columnHeaderIndex: number;
-  setToggleClassSortOrder: string;
-  ariaSort: string;
   isSortActive = false;
-  defaultSortColumnName  = 'amount';
+
   constructor(private tableDataService: TabledataService) { }
 
   ngOnInit() {
@@ -36,23 +36,15 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   defaultSort() {
-    this.ascSort(this.defaultSortColumnName);
+    this.ascSort(this.defaultSortColName);
   }
 
-  ascSort(columnHeader: string) {
-    this.sortByKeyAsc(this.allData, columnHeader);
+  ascSort(colHeader: string) {
+    this.sortByKeyAsc(this.allData, colHeader);
   }
 
-  descSort(columnHeader: string) {
-    this.sortByKeyDesc(this.allData, columnHeader);
-  }
-
-  sortByKeyDesc(array, key) {
-    return array.sort(function (a, b) {
-      const x = a[key];
-      const y = b[key];
-      return x > y ? -1 : x > y ? 1 : 0;
-    });
+  descSort(colHeader: string) {
+    this.sortByKeyDesc(this.allData, colHeader);
   }
 
   sortByKeyAsc(array, key) {
@@ -63,36 +55,33 @@ export class TableComponent implements OnInit, OnDestroy {
     });
   }
 
-  applySort(columnHeader: string, columnIndex: number) {
-    this.columnHeaderIndex = columnIndex;
-    if (this.sortOrder === undefined || this.sortOrder === '' || this.sortOrder === 'desc') {
-      this.sortOrder = 'asc';
-      this.ascSort(columnHeader);
-      this.setToggleClassSortOrder = 'ascending active';
-      this.ariaSort = 'ascending';
-    } else {
-      this.sortOrder = 'desc';
-      this.descSort(columnHeader);
-      this.setToggleClassSortOrder = 'descending active';
-      this.ariaSort = 'descending';
-    }
-  }
-
-  getSortClasses(rowIndex: number): string {
-    if (this.columnHeaderIndex === rowIndex) {
-      this.isSortActive = true;
-      return this.setToggleClassSortOrder;
-    } else {
-      return 'descending  ';
-    }
+  sortByKeyDesc(array, key) {
+    return array.sort(function (a, b) {
+      const x = a[key];
+      const y = b[key];
+      return x > y ? -1 : x > y ? 1 : 0;
+    });
   }
 
   getAriaSortOrder(rowIndex: number): string {
-    if (this.columnHeaderIndex === rowIndex) {
+    if (this.colIndex === rowIndex) {
       this.isSortActive = true;
-      return this.ariaSort;
+      return this.sortOrder;
     } else {
       return null;
+    }
+  }
+
+  applySort(colHeader: string, colIndex: number) {
+    this.colIndex = colIndex;
+    if (this.sortOrder === undefined || this.sortOrder === '' || this.sortOrder === 'descending') {
+      this.ascSort(colHeader);
+      this.isSortActive = true;
+      this.sortOrder = 'ascending';
+    } else {
+      this.descSort(colHeader);
+      this.isSortActive = true;
+      this.sortOrder = 'descending';
     }
   }
 


### PR DESCRIPTION
- fixed positioning of icon for narrow cols
- reduced code necessary to handle icons (asc/desc & active)
-- if the th **does not** have the aria-sort attribute, the icon is caret-down and the opacity is .5
-- if the th has the aria-sort attribute, the opacity is 1
-- if the th has the aria-sort attribute and the attribute value is ascending, the icon will be caret-up
-- if the th has the aria-sort attribute and the attribute value is descending, the icon will be caret-down