### PR TITLE
Below changes in sorting

### DIFF
--- a/src/app/table/table.component.html
+++ b/src/app/table/table.component.html
@@ -2,8 +2,8 @@
     <thead>
         <tr>
             <ng-container *ngIf="columnValue">
-                <th scope="col" [attr.aria-sort]="isSortActive ? getAriaSortOrder(i) : null"
-                    *ngFor="let column of columnValue; let i = index;">
+                <th scope="col" *ngFor="let column of columnValue; let i = index;"
+                    [attr.aria-sort]="isSortActive ? getAriaSortOrder(i) : 'null'">
                     <button class="th-sortable" (click)="applySort(column.key, i)">
                         {{column.value}}
                     </button>

--- a/src/app/table/table.component.ts
+++ b/src/app/table/table.component.ts
@@ -11,10 +11,10 @@ export class TableComponent implements OnInit, OnDestroy {
   allData: [] = [];
   columnValue: any;
   loadService: any;
-  defaultSortColName  = 'amount';
+  defaultSortColName = 'amount';
   colIndex: number;
-  sortOrder: string;
-  isSortActive = false;
+  sortOrder = 'ascending';
+  isSortActive = true;
 
   constructor(private tableDataService: TabledataService) { }
 
@@ -64,6 +64,14 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   getAriaSortOrder(rowIndex: number): string {
+    const columnIndex = this.columnValue.findIndex((item: { key: string; }, index: any) => {
+      if (item.key === this.defaultSortColName) {
+        return index;
+      }
+    });
+    if (columnIndex === rowIndex) {
+      return 'ascending';
+    }
     if (this.colIndex === rowIndex) {
       this.isSortActive = true;
       return this.sortOrder;
@@ -74,14 +82,17 @@ export class TableComponent implements OnInit, OnDestroy {
 
   applySort(colHeader: string, colIndex: number) {
     this.colIndex = colIndex;
-    if (this.sortOrder === undefined || this.sortOrder === '' || this.sortOrder === 'descending') {
+    if (this.defaultSortColName !== colHeader && typeof (this.sortOrder) !== 'undefined' ||
+      this.sortOrder === '' || this.sortOrder === 'descending') {
       this.ascSort(colHeader);
       this.isSortActive = true;
       this.sortOrder = 'ascending';
+      this.defaultSortColName = colHeader;
     } else {
       this.descSort(colHeader);
       this.isSortActive = true;
       this.sortOrder = 'descending';
+      this.defaultSortColName = '';
     }
   }
 


### PR DESCRIPTION
1) By default, there will be ascending sort applied to the table based on the default selected sort column name(for Amount).
2) On page load, for default sort aria-sort=”ascending” needs to apply for that ‘th’(for Amount only).
3) Once we Click on Amount then that column should be applied descending order.
4) Aria-sort only applied to the click column ‘th’ and show aria-sort according to sort order
5) If we click any of the other columns so there sorting should be ascending in every case.(whether it is in  ascending or descending order)
6) And according to that sort,  ‘Aria-sort’ will be applied for that ‘th’.